### PR TITLE
Do not stop workers when connection returns

### DIFF
--- a/lib/frenzy_bunnies/context.rb
+++ b/lib/frenzy_bunnies/context.rb
@@ -19,7 +19,12 @@ class FrenzyBunnies::Context
     (params[:username], params[:password] = @opts[:username], @opts[:password]) if @opts[:username] && @opts[:password]
     (params[:port] = @opts[:port]) if @opts[:port]
     @connection = MarchHare.connect(params)
-    @connection.add_shutdown_listener(lambda { |cause| @logger.error("Disconnected: #{cause}"); stop;})
+
+    # NOTE: Commented this out because the MarchHare connection would return, but the listeners were all stopped
+    #       with no mechanism to start them again automatically.  From local testing, an outage that returns
+    #       will continue to consume messages as expected when the connection returns if this stop is removed
+    #
+    # @connection.add_shutdown_listener(lambda { |cause| @logger.error("Disconnected: #{cause}"); stop;})
 
     @queue_factory = FrenzyBunnies::QueueFactory.new(@connection)
   end


### PR DESCRIPTION
So did some local testing where I would start the context and workers, then turn off my wifi for 10 seconds, and turn it back on.

What I noticed was that the connection would return, but the workers would all stop.  Since this is not desired, I dug into the source a bit.

Interestingly, the stop commands didn't even run until the connection was restored, which seems suspect already.  by commenting out this line, when the connection returned, it was able to pull messages off the queue and resume as normal.
