### PR TITLE
Allow passing in ssl param

### DIFF
--- a/lib/frenzy_bunnies/context.rb
+++ b/lib/frenzy_bunnies/context.rb
@@ -18,6 +18,7 @@ class FrenzyBunnies::Context
     params = {:host => @opts[:host], :heartbeat_interval => @opts[:heartbeat]}
     (params[:username], params[:password] = @opts[:username], @opts[:password]) if @opts[:username] && @opts[:password]
     (params[:port] = @opts[:port]) if @opts[:port]
+    (params[:ssl] = @opts[:ssl]) if @opts[:ssl]
     @connection = MarchHare.connect(params)
 
     # NOTE: Commented this out because the MarchHare connection would return, but the listeners were all stopped


### PR DESCRIPTION
Am playing around with Amazon RabbitMQ and needed to be able to pass this ssl: true parameter to be able to connect over their amqps protocol